### PR TITLE
Why was it there a " *4 " in BOOST option ?  + Price message improvement

### DIFF
--- a/LimitSwap.py
+++ b/LimitSwap.py
@@ -597,7 +597,7 @@ def buy(amount, inToken, outToken, gas, slippage, gaslimit, boost, fees, custom,
         if gas.lower() == 'boost':
             gas_check = client.eth.gasPrice
             gas_price = gas_check / 1000000000
-            gas = (gas_price * ((int(boost)*4)/100)) + gas_price
+            gas = (gas_price * ((int(boost))/100)) + gas_price
         else:
             gas = int(gas)
 

--- a/LimitSwap.py
+++ b/LimitSwap.py
@@ -489,7 +489,7 @@ def check_pool(inToken, outToken, symbol):
 
     return pooled
 
-def check_price(inToken, outToken, symbol, base, custom, routing):
+def check_price(inToken, outToken, symbol, base, custom, routing, buyamount):
     # CHECK GET RATE OF THE TOKEn
 
     DECIMALS = decimals(inToken)
@@ -505,26 +505,26 @@ def check_price(inToken, outToken, symbol, base, custom, routing):
             price_check = routerContract.functions.getAmountsOut(1 * DECIMALS, [inToken, weth, outToken]).call()[-1]
             DECIMALS = decimals(outToken)
             tokenPrice = price_check / DECIMALS
-            print(stamp, symbol, " Price ", tokenPrice,  base)
+            print(stamp, symbol, " Price ", tokenPrice,  base, "//// your buyprice =", buyamount, base)
         else:
             price_check = routerContract.functions.getAmountsOut(1 * DECIMALS, [inToken, weth]).call()[-1]
             DECIMALS = decimals(outToken)
             tokenPrice = price_check / DECIMALS
             price_output = "{:.18f}".format(tokenPrice)
-            print(stamp, symbol, "Price =", price_output,  base)
+            print(stamp, symbol, "Price =", price_output,  base, "//// your buyprice =", buyamount, base)
 
     else:
         if outToken != weth:
             price_check = routerContract.functions.getAmountsOut(1 * DECIMALS, [inToken, outToken]).call()[-1]
             DECIMALS = decimals(outToken)
             tokenPrice = price_check / DECIMALS
-            print(stamp, symbol, " Price ", tokenPrice,  base)
+            print(stamp, symbol, " Price ", tokenPrice,  base, "//// your buyprice =", buyamount, base)
         else:
             price_check = routerContract.functions.getAmountsOut(1 * DECIMALS, [inToken, weth]).call()[-1]
             DECIMALS = decimals(outToken)
             tokenPrice = price_check / DECIMALS
             price_output = "{:.18f}".format(tokenPrice)
-            print(stamp, symbol, "Price =", price_output,  base)
+            print(stamp, symbol, "Price =", price_output,  base, "//// your buyprice =", buyamount, base)
 
 
     return tokenPrice
@@ -1127,7 +1127,7 @@ def run():
                         outToken = weth
 
                     try:
-                        quote = check_price(inToken, outToken, token['SYMBOL'], token['BASESYMBOL'], token['USECUSTOMBASEPAIR'], token['LIQUIDITYINNATIVETOKEN'])
+                        quote = check_price(inToken, outToken, token['SYMBOL'], token['BASESYMBOL'], token['USECUSTOMBASEPAIR'], token['LIQUIDITYINNATIVETOKEN'], token['BUYPRICEINBASE'])
 
                     except Exception:
                         print(timestamp(), token['SYMBOL'], " Not Listed For Trade Yet... waiting for liquidity to be added on exchange")


### PR DESCRIPTION
We have lots of bugs with BOOST so I'm trying to see what's happening, and I don't understand why there was this " x4 " in the code ?

If BOOSTPERCENT = 30 , you just need to have GAS = GasPrice + (GasPrice * 30/100)

Don't you ?