### PR TITLE
Fix for LIQUIDITYCHECK + log improvements

### DIFF
--- a/LimitSwap.py
+++ b/LimitSwap.py
@@ -619,12 +619,13 @@ def sync(inToken, outToken):
 
 
 def check_pool(inToken, outToken, symbol):
+    # This function is made to calculate Liquidity of a token
     pair_address = factoryContract.functions.getPair(inToken, outToken).call()
     DECIMALS = decimals(outToken)
     pair_contract = client.eth.contract(address=pair_address, abi=lpAbi)
     reserves = pair_contract.functions.getReserves().call()
     pooled = reserves[1] / DECIMALS
-   # print("line 627 - LIQUIDITYAMOUNT:", pooled, "in token:", outToken)
+   # print("Debug LIQUIDITYAMOUNT line 627 :", pooled, "in token:", outToken)
 
     return pooled
 
@@ -1264,8 +1265,8 @@ def run():
                     try:
                         quote = check_price(inToken, outToken, token['SYMBOL'], token['BASESYMBOL'], token['USECUSTOMBASEPAIR'], token['LIQUIDITYINNATIVETOKEN'], token['BUYPRICEINBASE'])
                         pool = check_pool(inToken, outToken, token['BASESYMBOL'])
-                       # print("Current Liquidity Reserves ligne 1268:", float(pool))
-                       # print("inToken : ", inToken, "outToken :", outToken)        
+                       # print("Debug Liquidity Reserves ligne 1267:", float(pool))
+                       # print("Debug inToken : ", inToken, "outToken :", outToken)        
                                 
                     except Exception:
                         print(timestamp(), token['SYMBOL'], " Not Listed For Trade Yet... waiting for liquidity to be added on exchange")
@@ -1278,7 +1279,7 @@ def run():
 
                             if token["LIQUIDITYCHECK"].lower() == 'true':
                                 pool = check_pool(inToken, outToken, token['BASESYMBOL'])
-                                print("You have set LIQUIDITYCHECK = true. Current Liquidity = ", pool, "in token:", outToken)
+                                print("You have set LIQUIDITYCHECK = true. Current Liquidity = ", pool, " in token:", outToken)
                                 
                                 if float(token['LIQUIDITYAMOUNT']) <= float(pool):
                                     print(timestamp(), "Enough liquidity detected --> Buy Signal Found!")
@@ -1315,7 +1316,7 @@ def run():
 
 
                         else:
-                            print(timestamp(), "Max Position Size Reached for ", token['SYMBOL'])
+                            print(timestamp(), "You own more tokens than your MAXTOKENS parameter for ", token['SYMBOL'])
 
                             if quote > Decimal(token['SELLPRICEINBASE']):
                                 DECIMALS = decimals(inToken)

--- a/LimitSwap.py
+++ b/LimitSwap.py
@@ -1283,7 +1283,7 @@ def run():
                                 print(timestamp(), "Current", token['SYMBOL'], "Liquidity = ", int(pool), "in token:", outToken)
                                 
                                 if float(token['LIQUIDITYAMOUNT']) <= float(pool):
-                                    print(timestamp(), "Enough liquidity detected --> Buy Signal Found!")
+                                    print(timestamp(), "LIQUIDITYAMOUNT parameter =", int(token['LIQUIDITYAMOUNT']), " --> Enough liquidity detected : Buy Signal Found!")
                                     log_price = "{:.18f}".format(quote)
                                     logging.info("BuySignal Found @" + str(log_price))
                                     tx = buy(token['BUYAMOUNTINBASE'], outToken, inToken, token['GAS'], token['SLIPPAGE'], token['GASLIMIT'], token['BOOSTPERCENT'], token["HASFEES"], token['USECUSTOMBASEPAIR'], token['SYMBOL'], token['BASESYMBOL'], token['LIQUIDITYINNATIVETOKEN'])

--- a/LimitSwap.py
+++ b/LimitSwap.py
@@ -593,7 +593,7 @@ def check_approval(address, balance):
 
 def check_bnb_balance():
     balance = client.eth.getBalance(settings['WALLETADDRESS'])
-    print(timestamp(), "Current Wallet Balance is :", Web3.fromWei(balance, 'ETH'), base_symbol)
+    print(timestamp(), "Current Wallet Balance is :", Web3.fromWei(balance, 'ether'), base_symbol)
     return balance
 
 def check_balance(address, symbol):
@@ -670,10 +670,10 @@ def check_price(inToken, outToken, symbol, base, custom, routing, buyamount):
     return tokenPrice
 
 def wait_for_tx(tx_hash, address, check):
-    print(timestamp(), "Waiting for TX to Confirm....")
+    print(timestamp(), "Waiting 1 minute for TX to Confirm....")
     timeout = time() + 60
     while True:
-        print(timestamp(), ".........waiting............")
+        print(timestamp(), ".........Waiting 1 minute for TX to Confirm............")
         try:
             txn_receipt = client.eth.getTransactionReceipt(tx_hash)
             return txn_receipt['status']
@@ -685,8 +685,8 @@ def wait_for_tx(tx_hash, address, check):
             return txn_receipt['status']
 
         elif time() > timeout:
-            print(timestamp(), "Transaction Timed Out, Breaking Check Cycle....")
-            logging.info("Transaction Timed Out, Breaking Check Cycle....")
+            print(timestamp(), "Transaction was not confirmed after 1 minute, breaking Check Cycle....")
+            logging.info("Transaction was not confirmed after 1 minute, breaking Check Cycle....")
             break
 
 
@@ -694,7 +694,7 @@ def wait_for_tx(tx_hash, address, check):
     if check == True:
         timeout = time() + 30
         while True:
-            print(timestamp(), ".........Balance Check After Purchase............")
+            print(timestamp(), ".........Waiting 30s to check tokens balance in your wallet after purchase............")
 
             balance = check_balance(address, address)
 
@@ -1279,7 +1279,8 @@ def run():
 
                             if token["LIQUIDITYCHECK"].lower() == 'true':
                                 pool = check_pool(inToken, outToken, token['BASESYMBOL'])
-                                print("You have set LIQUIDITYCHECK = true. Current Liquidity = ", pool, " in token:", outToken)
+                                print(timestamp(), "You have set LIQUIDITYCHECK = true.")
+                                print(timestamp(), "Current", token['SYMBOL'], "Liquidity = ", int(pool), "in token:", outToken)
                                 
                                 if float(token['LIQUIDITYAMOUNT']) <= float(pool):
                                     print(timestamp(), "Enough liquidity detected --> Buy Signal Found!")
@@ -1297,7 +1298,7 @@ def run():
                                     else:
                                         pass
                                 else:
-                                    print(timestamp(), "Liquidity for", token['SYMBOL'], "is inferior to your LIQUIDITYAMOUNT parameter : bot will not buy")
+                                    print(timestamp(), "LIQUIDITYAMOUNT parameter =", int(token['LIQUIDITYAMOUNT']), " : not enough liquidity, bot will not buy")
 
                             else:
                                 print(timestamp(), "Buy Signal Found!")

--- a/LimitSwap.py
+++ b/LimitSwap.py
@@ -734,7 +734,7 @@ def buy(amount, inToken, outToken, gas, slippage, gaslimit, boost, fees, custom,
         if gas.lower() == 'boost':
             gas_check = client.eth.gasPrice
             gas_price = gas_check / 1000000000
-            gas = (gas_price * ((int(boost)*4)/100)) + gas_price
+            gas = (gas_price * ((int(boost))/100)) + gas_price
         else:
             gas = int(gas)
 


### PR DESCRIPTION
This pull request have several topics : 

1/ I had broken the bot with a previous pull request ! line 596, it must be 'ether' and not 'ETH' or Buy do not work

2/ I fixed the LiquidityCheck amount : line 627, it's reserves[1] and not "reserves[-1]" as it was before
--> LiquidityCheck work for every token ! Custom base pair or not

3/ Several logs improvements : 
    - for LiquidityCheck, it looks like this : 
![image](https://user-images.githubusercontent.com/70858574/143963634-a021af56-c463-4f3e-8324-396a2ae9bd02.png)
   - for the waiting time when you made a Buy order