### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.10-slim
+
+RUN apt-get update && \
+    apt-get install -y python3-pip \
+    python3-dev
+
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+WORKDIR /app
+
+ADD . /app
+
+RUN useradd --create-home limitswap
+USER root
+RUN chown limitswap:limitswap -R /app/
+USER limitswap
+
+RUN pip install --upgrade pip --no-warn-script-location
+RUN pip install -r requirements.txt --no-warn-script-location
+
+CMD ["python", "LimitSwap.py"]


### PR DESCRIPTION
Hi there!

PR to add Docker support to LimitSwap. Haven't updated the README with instructions on how to run it, but I'll write them down here.

## Requirements

* MacOS and Windows users require Docker for Desktop <https://www.docker.com/products/docker-desktop>
* Ubuntu Linux require Docker installed `sudo apt-get install docker.io`

## Usage

Navigate into the bot directory and build the Docker image by executing the following command:

`docker build -t limit_swap_v4 .`

(For MacOS and Linux) Still within the main directory you can run Docker via:

`docker run --rm --name limit-swap_v4 -it -v $(pwd)/settings.json:/app/settings.json -v $(pwd)/tokens.json:/app/tokens.json limit_swap_v4`

(For Windows with Powershell)

`docker run --rm --name limit-swap_v4 -it -v $PWD/settings.json:/app/settings.json -v $PWD/tokens.json:/app/tokens.json limit_swap_v4`

If you wish to run the container in the background please include -d for detached. 

The streaming container logs can be visualised with `docker logs -f limit_swap_v4`.

To stop the bot `docker stop limit_swap_v4`.


great job with the bot! 
